### PR TITLE
Avoid Elasticsearch initialization in MySQL mode; add Python 3.6 `Protocol` fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### 1) Apply the MySQL search schema
 
-This repository ships the SQL schema and stored procedures for the MySQL search index. Apply them manually once per database:
+This repository ships the SQL schema for the MySQL search index. Apply it manually once per database:
 
 ```bash
 mysql -u <user> -p <db> < migrations/mysql_search_index.sql

--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# folklore!
+# Folklore
+
+## MySQL search backend runbook
+
+### 1) Apply the MySQL search schema
+
+This repository ships the SQL schema and stored procedures for the MySQL search index. Apply them manually once per database:
+
+```bash
+mysql -u <user> -p <db> < migrations/mysql_search_index.sql
+```
+
+### 2) Install the required NLTK data
+
+Sentence splitting relies on the NLTK `punkt` model:
+
+```bash
+python -m nltk.downloader punkt
+```
+
+### 3) Select a search backend
+
+Set the backend via environment variable before starting the app:
+
+```bash
+export SEARCH_BACKEND=mysql
+# or
+export SEARCH_BACKEND=elasticsearch
+```
+
+### 4) Build or refresh the MySQL index
+
+Use the Flask CLI to build the MySQL sentence index:
+
+```bash
+flask search-index rebuild --truncate --batch-size 1000
+```
+
+To index a single text by id:
+
+```bash
+flask search-index text --id 123
+```
+
+### 5) MySQL FULLTEXT configuration notes
+
+The sentence index uses a MySQL FULLTEXT index. MySQL may ignore short tokens or apply stopword filtering by default. If you need short tokens or specific languages, review and adjust the MySQL configuration options below, then rebuild the index:
+
+- `innodb_ft_min_token_size`
+- `ft_min_word_len`
+- `innodb_ft_enable_stopword`
+- `innodb_ft_server_stopword_table`
+
+After changing any FULLTEXT settings, restart MySQL and rebuild the index with `flask search-index rebuild --truncate`.

--- a/folklore_app/__init__.py
+++ b/folklore_app/__init__.py
@@ -1,2 +1,2 @@
-# from folklore_app.tsakorpus_search import app
 from folklore_app.main_app import application
+import folklore_app.tsakorpus_search  # noqa: F401

--- a/folklore_app/main_app.py
+++ b/folklore_app/main_app.py
@@ -115,18 +115,6 @@ def register_search_cli(application):
     def index_text(text_id):
         mysql_indexer.index_text(text_id)
 
-    @search_index.command("update")
-    @click.option("--since", "since_timestamp", required=True)
-    def update(since_timestamp):
-        # Incremental reindexing is currently disabled because the Texts model
-        # does not yet provide an appropriate timestamp field for tracking updates.
-        # Once such a field (e.g. `updated_at`) is added and `mysql_indexer`
-        # is updated accordingly, this command can be re-enabled.
-        raise click.ClickException(
-            "The 'search-index update' command is currently disabled: "
-            "incremental index updates are not supported yet."
-        )
-
 
 application = create_app()
 login_manager.init_app(application)

--- a/folklore_app/main_app.py
+++ b/folklore_app/main_app.py
@@ -14,6 +14,7 @@ from urllib.parse import quote
 import pandas as pd
 import plotly.express as px
 from pymystem3 import Mystem
+import click
 from nltk.tokenize import sent_tokenize
 from PIL import Image
 from io import BytesIO
@@ -48,6 +49,7 @@ from folklore_app.settings import APP_ROOT, CONFIG, LINK_PREFIX, DATA_PATH, GALL
 from folklore_app.const import ACCENTS, CATEGORIES
 from folklore_app.tables import TextForTable
 from folklore_app.db_search import get_result, database_fields
+from folklore_app.search_backends import mysql_indexer
 
 try:
     m = Mystem()
@@ -90,7 +92,33 @@ def create_app():
     )
     admin = admin_views(admin)
     babel = Babel(application)
+    register_search_cli(application)
     return application
+
+
+def register_search_cli(application):
+    @application.cli.group("search-index")
+    def search_index():
+        """Manage search index for the search backend."""
+
+    @search_index.command("rebuild")
+    @click.option("--truncate/--no-truncate", default=False)
+    @click.option("--batch-size", default=1000, type=int)
+    def rebuild(truncate, batch_size):
+        mysql_indexer.rebuild_index(
+            truncate_first=truncate,
+            batch_size=batch_size,
+        )
+
+    @search_index.command("text")
+    @click.option("--id", "text_id", required=True, type=int)
+    def index_text(text_id):
+        mysql_indexer.index_text(text_id)
+
+    @search_index.command("update")
+    @click.option("--since", "since_timestamp", required=True)
+    def update(since_timestamp):
+        mysql_indexer.reindex_changed_texts(since_timestamp)
 
 
 application = create_app()
@@ -840,4 +868,3 @@ def upload_images():
     result = pd.DataFrame(result, columns=["id", "file", "name"])
 
     return render_template("upload_images.html", result=result.to_html(), df_len=result.shape[0])
-

--- a/folklore_app/main_app.py
+++ b/folklore_app/main_app.py
@@ -118,7 +118,14 @@ def register_search_cli(application):
     @search_index.command("update")
     @click.option("--since", "since_timestamp", required=True)
     def update(since_timestamp):
-        mysql_indexer.reindex_changed_texts(since_timestamp)
+        # Incremental reindexing is currently disabled because the Texts model
+        # does not yet provide an appropriate timestamp field for tracking updates.
+        # Once such a field (e.g. `updated_at`) is added and `mysql_indexer`
+        # is updated accordingly, this command can be re-enabled.
+        raise click.ClickException(
+            "The 'search-index update' command is currently disabled: "
+            "incremental index updates are not supported yet."
+        )
 
 
 application = create_app()

--- a/folklore_app/search_backends/__init__.py
+++ b/folklore_app/search_backends/__init__.py
@@ -1,0 +1,6 @@
+from folklore_app.search_backends.base import SearchBackend
+from folklore_app.search_backends.es_backend import ESSearchBackend
+from folklore_app.search_backends.mysql_backend import MySQLSearchBackend
+from . import mysql_indexer
+
+__all__ = ["SearchBackend", "ESSearchBackend", "MySQLSearchBackend", "mysql_indexer"]

--- a/folklore_app/search_backends/base.py
+++ b/folklore_app/search_backends/base.py
@@ -1,0 +1,19 @@
+try:
+    from typing import Protocol
+except ImportError:  # pragma: no cover - fallback for Python 3.6
+    from typing_extensions import Protocol
+
+from werkzeug.datastructures import ImmutableMultiDict
+
+
+class SearchBackend(Protocol):
+    def search_sentences(
+        self,
+        request_args: ImmutableMultiDict,
+        page: int,
+        session_data: dict,
+    ):
+        raise NotImplementedError
+
+    def get_sentence_context(self, n: int, session_data: dict):
+        raise NotImplementedError

--- a/folklore_app/search_backends/es_backend.py
+++ b/folklore_app/search_backends/es_backend.py
@@ -39,9 +39,12 @@ class ESSearchBackend:
         if "subcorpus_enabled" in hits:
             hits_processed["subcorpus_enabled"] = True
         self._sync_page_data(hits_processed["page"], hits_processed)
-        max_page_number = (min(hits_processed["n_sentences"], 1000) - 1) // hits_processed[
-            "page_size"
-        ] + 1
+        max_page_number = max(
+            1,
+            (min(hits_processed["n_sentences"], 1000) - 1)
+            // hits_processed["page_size"]
+            + 1,
+        )
         hits_processed["too_many_hits"] = 1000 < hits_processed["n_sentences"]
         return {
             "data": hits_processed,

--- a/folklore_app/search_backends/es_backend.py
+++ b/folklore_app/search_backends/es_backend.py
@@ -1,0 +1,52 @@
+class ESSearchBackend:
+    def __init__(
+        self,
+        *,
+        find_sentences_json,
+        add_sent_to_session,
+        sent_viewer,
+        settings,
+        get_session_data,
+        set_session_data,
+        sync_page_data,
+        build_context,
+    ):
+        self._find_sentences_json = find_sentences_json
+        self._add_sent_to_session = add_sent_to_session
+        self._sent_viewer = sent_viewer
+        self._settings = settings
+        self._get_session_data = get_session_data
+        self._set_session_data = set_session_data
+        self._sync_page_data = sync_page_data
+        self._build_context = build_context
+
+    def search_sentences(self, request_args, page, session_data):
+        if page < 0:
+            self._set_session_data("page_data", {})
+            page = 0
+        hits = self._find_sentences_json(page=page)
+        self._add_sent_to_session(hits)
+        hits_processed = self._sent_viewer.process_sent_json(
+            hits,
+            translit=self._get_session_data("translit"),
+        )
+        hits_processed["page"] = self._get_session_data("page")
+        hits_processed["page_size"] = self._get_session_data("page_size")
+        hits_processed["languages"] = self._settings["languages"]
+        hits_processed["media"] = self._settings["media"]
+        hits_processed["subcorpus_enabled"] = False
+        hits_processed["n_sentences"] = hits_processed["n_sentences"]["value"]
+        if "subcorpus_enabled" in hits:
+            hits_processed["subcorpus_enabled"] = True
+        self._sync_page_data(hits_processed["page"], hits_processed)
+        max_page_number = (min(hits_processed["n_sentences"], 1000) - 1) // hits_processed[
+            "page_size"
+        ] + 1
+        hits_processed["too_many_hits"] = 1000 < hits_processed["n_sentences"]
+        return {
+            "data": hits_processed,
+            "max_page_number": max_page_number,
+        }
+
+    def get_sentence_context(self, n, session_data):
+        return self._build_context(n)

--- a/folklore_app/search_backends/mysql_backend.py
+++ b/folklore_app/search_backends/mysql_backend.py
@@ -4,6 +4,7 @@ import re
 from sqlalchemy import text as sql_text
 
 from folklore_app.models import db
+from folklore_app.search_backends import mysql_indexer
 
 
 class MySQLSearchBackend:
@@ -13,7 +14,8 @@ class MySQLSearchBackend:
     def search_sentences(self, request_args, page, session_data):
         request_args = self._resolve_request_args(request_args, session_data)
         query_text = self._build_query_text(request_args)
-        if not query_text:
+        normalized_query = mysql_indexer.normalize(query_text)
+        if not normalized_query:
             return {
                 "data": self._empty_results(page=1, page_size=10),
                 "max_page_number": 1,
@@ -22,9 +24,9 @@ class MySQLSearchBackend:
         page_size = self._get_page_size(request_args)
         page = self._normalize_page(page)
         offset = (page - 1) * page_size
-        terms = self._tokenize(query_text)
-        boolean_query = self._build_boolean_query(terms, precise=precise)
-        like_query = f"%{query_text.strip()}%"
+        terms = self._tokenize(normalized_query)
+        boolean_query = self._build_boolean_query(terms)
+        phrase_query = self._build_phrase_query(normalized_query)
 
         if precise:
             total_rows = db.session.execute(
@@ -32,32 +34,32 @@ class MySQLSearchBackend:
                     """
                     SELECT COUNT(*) AS total
                     FROM texts_sentences
-                    WHERE content_norm LIKE :q
+                    WHERE MATCH(content_norm) AGAINST (:q IN BOOLEAN MODE)
                     """
                 ),
-                {"q": like_query},
+                {"q": phrase_query},
             ).scalar()
             total_docs = db.session.execute(
                 sql_text(
                     """
                     SELECT COUNT(DISTINCT text_id) AS total
                     FROM texts_sentences
-                    WHERE content_norm LIKE :q
+                    WHERE MATCH(content_norm) AGAINST (:q IN BOOLEAN MODE)
                     """
                 ),
-                {"q": like_query},
+                {"q": phrase_query},
             ).scalar()
             results = db.session.execute(
                 sql_text(
                     """
                     SELECT id, text_id, sent_no, content, content_norm
                     FROM texts_sentences
-                    WHERE content_norm LIKE :q
+                    WHERE MATCH(content_norm) AGAINST (:q IN BOOLEAN MODE)
                     ORDER BY text_id, sent_no
                     LIMIT :limit OFFSET :offset
                     """
                 ),
-                {"q": like_query, "limit": page_size, "offset": offset},
+                {"q": phrase_query, "limit": page_size, "offset": offset},
             ).mappings()
         else:
             total_rows = db.session.execute(
@@ -118,9 +120,9 @@ class MySQLSearchBackend:
             "subcorpus_enabled": False,
             "languages": ["default"],
             "media": False,
-            "src_alignment": None,
+            "src_alignment": {},
         }
-        max_page_number = (min(data["n_sentences"], 1000) - 1) // page_size + 1
+        max_page_number = max(1, (min(data["n_sentences"], 1000) - 1) // page_size + 1)
         data["too_many_hits"] = 1000 < data["n_sentences"]
         return {"data": data, "max_page_number": max_page_number}
 
@@ -198,12 +200,15 @@ class MySQLSearchBackend:
     def _tokenize(self, text):
         return [token for token in re.split(r"\s+", text.strip()) if token]
 
-    def _build_boolean_query(self, terms, precise=False):
+    def _build_boolean_query(self, terms):
         if not terms:
             return ""
-        if precise:
-            return " ".join(terms)
         return " ".join(f"+{term}*" for term in terms)
+
+    def _build_phrase_query(self, query_text):
+        if not query_text:
+            return ""
+        return f'"{query_text}"'
 
     def _build_context(self, row, terms, precise=False):
         header = f"Text ID {row['text_id']} · Sentence {row['sent_no'] + 1}"
@@ -241,6 +246,6 @@ class MySQLSearchBackend:
             "subcorpus_enabled": False,
             "languages": ["default"],
             "media": False,
-            "src_alignment": None,
+            "src_alignment": {},
             "too_many_hits": False,
         }

--- a/folklore_app/search_backends/mysql_backend.py
+++ b/folklore_app/search_backends/mysql_backend.py
@@ -1,0 +1,238 @@
+import html
+import re
+
+from sqlalchemy import text as sql_text
+
+from folklore_app.models import db
+
+
+class MySQLSearchBackend:
+    def __init__(self, *, max_page_size=100):
+        self._max_page_size = max_page_size
+
+    def search_sentences(self, request_args, page, session_data):
+        query_text = self._build_query_text(request_args)
+        if not query_text:
+            return {
+                "data": self._empty_results(page=1, page_size=10),
+                "max_page_number": 1,
+            }
+        precise = request_args.get("precise") == "on"
+        page_size = self._get_page_size(request_args)
+        page = self._normalize_page(page)
+        offset = (page - 1) * page_size
+        terms = self._tokenize(query_text)
+        boolean_query = self._build_boolean_query(terms, precise=precise)
+        like_query = f"%{query_text.strip()}%"
+
+        total_rows = db.session.execute(
+            sql_text(
+                """
+                SELECT COUNT(*) AS total
+                FROM texts_sentences
+                WHERE MATCH(content_norm) AGAINST (:q IN BOOLEAN MODE)
+                """
+            ),
+            {"q": boolean_query},
+        ).scalar()
+        total_docs = db.session.execute(
+            sql_text(
+                """
+                SELECT COUNT(DISTINCT text_id) AS total
+                FROM texts_sentences
+                WHERE MATCH(content_norm) AGAINST (:q IN BOOLEAN MODE)
+                """
+            ),
+            {"q": boolean_query},
+        ).scalar()
+
+        if not total_rows and precise:
+            total_rows = db.session.execute(
+                sql_text(
+                    """
+                    SELECT COUNT(*) AS total
+                    FROM texts_sentences
+                    WHERE content_norm LIKE :q
+                    """
+                ),
+                {"q": like_query},
+            ).scalar()
+            total_docs = db.session.execute(
+                sql_text(
+                    """
+                    SELECT COUNT(DISTINCT text_id) AS total
+                    FROM texts_sentences
+                    WHERE content_norm LIKE :q
+                    """
+                ),
+                {"q": like_query},
+            ).scalar()
+
+        if precise and total_rows:
+            results = db.session.execute(
+                sql_text(
+                    """
+                    SELECT id, text_id, sent_no, content, content_norm
+                    FROM texts_sentences
+                    WHERE content_norm LIKE :q
+                    ORDER BY text_id, sent_no
+                    LIMIT :limit OFFSET :offset
+                    """
+                ),
+                {"q": like_query, "limit": page_size, "offset": offset},
+            ).mappings()
+        else:
+            results = db.session.execute(
+                sql_text(
+                    """
+                    SELECT id, text_id, sent_no, content, content_norm,
+                           MATCH(content_norm) AGAINST (:q IN BOOLEAN MODE) AS score
+                    FROM texts_sentences
+                    WHERE MATCH(content_norm) AGAINST (:q IN BOOLEAN MODE)
+                    ORDER BY score DESC, text_id, sent_no
+                    LIMIT :limit OFFSET :offset
+                    """
+                ),
+                {"q": boolean_query, "limit": page_size, "offset": offset},
+            ).mappings()
+
+        rows = list(results)
+        contexts = [
+            self._build_context(row, terms, precise=precise)
+            for row in rows
+        ]
+
+        session_data["mysql_hit_ids"] = [
+            {"text_id": row["text_id"], "sent_no": row["sent_no"]}
+            for row in rows
+        ]
+        session_data["mysql_last_terms"] = terms
+
+        data = {
+            "contexts": contexts,
+            "n_sentences": int(total_rows or 0),
+            "n_docs": int(total_docs or 0),
+            "n_occurrences": 0,
+            "page": page,
+            "page_size": page_size,
+            "timeout": False,
+            "message": None,
+            "subcorpus_enabled": False,
+            "languages": ["default"],
+            "media": False,
+            "src_alignment": None,
+        }
+        max_page_number = (min(data["n_sentences"], 1000) - 1) // page_size + 1
+        data["too_many_hits"] = 1000 < data["n_sentences"]
+        return {"data": data, "max_page_number": max_page_number}
+
+    def get_sentence_context(self, n, session_data):
+        hit_ids = session_data.get("mysql_hit_ids", [])
+        if n < 0 or n >= len(hit_ids):
+            return {}
+        hit = hit_ids[n]
+        text_id = hit["text_id"]
+        sent_no = hit["sent_no"]
+        terms = session_data.get("mysql_last_terms", [])
+
+        prev_row = db.session.execute(
+            sql_text(
+                """
+                SELECT content
+                FROM texts_sentences
+                WHERE text_id = :text_id AND sent_no = :sent_no
+                """
+            ),
+            {"text_id": text_id, "sent_no": sent_no - 1},
+        ).scalar()
+        next_row = db.session.execute(
+            sql_text(
+                """
+                SELECT content
+                FROM texts_sentences
+                WHERE text_id = :text_id AND sent_no = :sent_no
+                """
+            ),
+            {"text_id": text_id, "sent_no": sent_no + 1},
+        ).scalar()
+
+        return {
+            "n": n,
+            "languages": {
+                "default": {
+                    "prev": self._highlight(prev_row or "", terms),
+                    "next": self._highlight(next_row or "", terms),
+                }
+            },
+        }
+
+    def _normalize_page(self, page):
+        if page <= 0:
+            return 1
+        return page
+
+    def _get_page_size(self, request_args):
+        try:
+            page_size = int(request_args.get("page_size", 10))
+        except (TypeError, ValueError):
+            page_size = 10
+        page_size = max(1, min(page_size, self._max_page_size))
+        return page_size
+
+    def _build_query_text(self, request_args):
+        txt = request_args.get("txt", "").strip()
+        if txt:
+            return txt
+        wf = request_args.get("wf1", "").strip()
+        lex = request_args.get("lex1", "").strip()
+        return " ".join([part for part in (wf, lex) if part])
+
+    def _tokenize(self, text):
+        return [token for token in re.split(r"\s+", text.strip()) if token]
+
+    def _build_boolean_query(self, terms, precise=False):
+        if not terms:
+            return ""
+        if precise:
+            return " ".join(terms)
+        return " ".join(f"+{term}*" for term in terms)
+
+    def _build_context(self, row, terms, precise=False):
+        header = f"Text ID {row['text_id']} · Sentence {row['sent_no'] + 1}"
+        highlighted = self._highlight(row["content"], terms)
+        return {
+            "toggled_on": True,
+            "header": header,
+            "languages": {
+                "default": {
+                    "text": highlighted,
+                }
+            },
+        }
+
+    def _highlight(self, content, terms):
+        escaped = html.escape(content or "")
+        if not terms:
+            return escaped
+        pattern = re.compile(
+            "(" + "|".join(re.escape(term) for term in terms) + ")",
+            flags=re.IGNORECASE,
+        )
+        return pattern.sub(r'<span class="word w_highlighted">\1</span>', escaped)
+
+    def _empty_results(self, page, page_size):
+        return {
+            "contexts": [],
+            "n_sentences": 0,
+            "n_docs": 0,
+            "n_occurrences": 0,
+            "page": page,
+            "page_size": page_size,
+            "timeout": False,
+            "message": None,
+            "subcorpus_enabled": False,
+            "languages": ["default"],
+            "media": False,
+            "src_alignment": None,
+            "too_many_hits": False,
+        }

--- a/folklore_app/search_backends/mysql_backend.py
+++ b/folklore_app/search_backends/mysql_backend.py
@@ -11,6 +11,7 @@ class MySQLSearchBackend:
         self._max_page_size = max_page_size
 
     def search_sentences(self, request_args, page, session_data):
+        request_args = self._resolve_request_args(request_args, session_data)
         query_text = self._build_query_text(request_args)
         if not query_text:
             return {
@@ -25,28 +26,7 @@ class MySQLSearchBackend:
         boolean_query = self._build_boolean_query(terms, precise=precise)
         like_query = f"%{query_text.strip()}%"
 
-        total_rows = db.session.execute(
-            sql_text(
-                """
-                SELECT COUNT(*) AS total
-                FROM texts_sentences
-                WHERE MATCH(content_norm) AGAINST (:q IN BOOLEAN MODE)
-                """
-            ),
-            {"q": boolean_query},
-        ).scalar()
-        total_docs = db.session.execute(
-            sql_text(
-                """
-                SELECT COUNT(DISTINCT text_id) AS total
-                FROM texts_sentences
-                WHERE MATCH(content_norm) AGAINST (:q IN BOOLEAN MODE)
-                """
-            ),
-            {"q": boolean_query},
-        ).scalar()
-
-        if not total_rows and precise:
+        if precise:
             total_rows = db.session.execute(
                 sql_text(
                     """
@@ -67,8 +47,6 @@ class MySQLSearchBackend:
                 ),
                 {"q": like_query},
             ).scalar()
-
-        if precise and total_rows:
             results = db.session.execute(
                 sql_text(
                     """
@@ -82,6 +60,26 @@ class MySQLSearchBackend:
                 {"q": like_query, "limit": page_size, "offset": offset},
             ).mappings()
         else:
+            total_rows = db.session.execute(
+                sql_text(
+                    """
+                    SELECT COUNT(*) AS total
+                    FROM texts_sentences
+                    WHERE MATCH(content_norm) AGAINST (:q IN BOOLEAN MODE)
+                    """
+                ),
+                {"q": boolean_query},
+            ).scalar()
+            total_docs = db.session.execute(
+                sql_text(
+                    """
+                    SELECT COUNT(DISTINCT text_id) AS total
+                    FROM texts_sentences
+                    WHERE MATCH(content_norm) AGAINST (:q IN BOOLEAN MODE)
+                    """
+                ),
+                {"q": boolean_query},
+            ).scalar()
             results = db.session.execute(
                 sql_text(
                     """
@@ -164,6 +162,7 @@ class MySQLSearchBackend:
                     "next": self._highlight(next_row or "", terms),
                 }
             },
+            "src_alignment": {},
         }
 
     def _normalize_page(self, page):
@@ -186,6 +185,15 @@ class MySQLSearchBackend:
         wf = request_args.get("wf1", "").strip()
         lex = request_args.get("lex1", "").strip()
         return " ".join([part for part in (wf, lex) if part])
+
+    def _resolve_request_args(self, request_args, session_data):
+        if request_args:
+            session_data["mysql_last_request_args"] = dict(request_args)
+            return request_args
+        stored = session_data.get("mysql_last_request_args")
+        if stored:
+            return stored
+        return request_args
 
     def _tokenize(self, text):
         return [token for token in re.split(r"\s+", text.strip()) if token]

--- a/folklore_app/search_backends/mysql_indexer.py
+++ b/folklore_app/search_backends/mysql_indexer.py
@@ -1,0 +1,103 @@
+import re
+
+from nltk.tokenize import sent_tokenize
+from sqlalchemy import text as sql_text
+
+from folklore_app.models import db, Texts
+
+
+def normalize(text):
+    lowered = (text or "").lower().replace("ё", "е")
+    cleaned = re.sub(r"[^\w\s-]", " ", lowered, flags=re.UNICODE)
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned
+
+
+def split_sentences(raw_text):
+    if not raw_text:
+        return []
+    try:
+        return sent_tokenize(raw_text)
+    except LookupError as exc:
+        raise RuntimeError(
+            "NLTK punkt tokenizer data is missing. "
+            "Run `python -m nltk.downloader punkt` before indexing."
+        ) from exc
+
+
+def rebuild_index(truncate_first=False, batch_size=1000):
+    if truncate_first:
+        db.session.execute(sql_text("CALL sp_texts_sentences_reset()"))
+        db.session.commit()
+
+    query = Texts.query.order_by(Texts.id)
+    total = query.count()
+    offset = 0
+    while offset < total:
+        texts = query.offset(offset).limit(batch_size).all()
+        _index_texts(texts)
+        offset += batch_size
+
+
+def index_text(text_id, delete_existing=True):
+    text = Texts.query.filter_by(id=text_id).one_or_none()
+    if text is None:
+        raise ValueError(f"Text {text_id} not found.")
+    if delete_existing:
+        db.session.execute(
+            sql_text("CALL sp_texts_sentences_delete_for_text(:text_id)"),
+            {"text_id": text_id},
+        )
+        db.session.commit()
+    _index_texts([text])
+
+
+def reindex_changed_texts(since_timestamp):
+    if not hasattr(Texts, "updated_at"):
+        raise RuntimeError(
+            "Texts.updated_at is not available; use rebuild or index_text instead."
+        )
+    texts = Texts.query.filter(Texts.updated_at >= since_timestamp).all()
+    if texts:
+        _index_texts(texts)
+
+
+def _index_texts(texts):
+    rows = []
+    for text in texts:
+        sentences = split_sentences(text.raw_text)
+        for sent_no, sentence in enumerate(sentences):
+            rows.append(
+                {
+                    "text_id": text.id,
+                    "sent_no": sent_no,
+                    "lang": "default",
+                    "content": sentence,
+                    "content_norm": normalize(sentence),
+                    "year": text.year,
+                    "geo": _get_geo(text),
+                }
+            )
+    if rows:
+        db.session.execute(
+            sql_text(
+                """
+                INSERT INTO texts_sentences
+                    (text_id, sent_no, lang, content, content_norm, year, geo)
+                VALUES
+                    (:text_id, :sent_no, :lang, :content, :content_norm, :year, :geo)
+                """
+            ),
+            rows,
+        )
+        db.session.commit()
+
+
+def _get_geo(text):
+    if text.geo and getattr(text.geo, "village", None):
+        return text.geo.village.name
+    if text.geo and getattr(text.geo, "district", None):
+        return text.geo.district.name
+    if text.geo and getattr(text.geo, "region", None):
+        return text.geo.region.name
+    return None

--- a/folklore_app/search_backends/mysql_indexer.py
+++ b/folklore_app/search_backends/mysql_indexer.py
@@ -27,7 +27,7 @@ def split_sentences(raw_text):
 
 def rebuild_index(truncate_first=False, batch_size=1000):
     if truncate_first:
-        db.session.execute(sql_text("CALL sp_texts_sentences_reset()"))
+        db.session.execute(sql_text("TRUNCATE TABLE texts_sentences"))
         db.session.commit()
 
     query = Texts.query.order_by(Texts.id)
@@ -45,7 +45,7 @@ def index_text(text_id, delete_existing=True):
         raise ValueError(f"Text {text_id} not found.")
     if delete_existing:
         db.session.execute(
-            sql_text("CALL sp_texts_sentences_delete_for_text(:text_id)"),
+            sql_text("DELETE FROM texts_sentences WHERE text_id = :text_id"),
             {"text_id": text_id},
         )
         db.session.commit()

--- a/folklore_app/search_settings.py
+++ b/folklore_app/search_settings.py
@@ -1,0 +1,14 @@
+import os
+
+
+def get_search_backend():
+    backend = os.getenv("SEARCH_BACKEND", "elasticsearch").lower()
+    allowed = {"elasticsearch", "mysql"}
+    if backend not in allowed:
+        raise ValueError(
+            f"SEARCH_BACKEND must be one of {sorted(allowed)}; got {backend!r}"
+        )
+    return backend
+
+
+SEARCH_BACKEND = get_search_backend()

--- a/folklore_app/tsakorpus_search.py
+++ b/folklore_app/tsakorpus_search.py
@@ -24,10 +24,11 @@ import re
 from flask import render_template, request
 
 
-from folklore_app.main_app import app
+from folklore_app.main_app import application as app
 from folklore_app.settings import SETTINGS_DIR
-from folklore_app.search_engine.response_processors import SentenceViewer
-from folklore_app.search_engine.client import SearchClient
+from folklore_app.search_backends.es_backend import ESSearchBackend
+from folklore_app.search_backends.mysql_backend import MySQLSearchBackend
+from folklore_app.search_settings import SEARCH_BACKEND
 
 MAX_PAGE_SIZE = 100  # maximum number of sentences per page
 
@@ -40,29 +41,36 @@ corpus_name = settings['corpus_name']
 if settings['max_docs_retrieve'] >= 10000:
     settings['max_docs_retrieve'] = 9999
 
-from folklore_app.search_engine.corpus_settings import CorpusSettings
-st = CorpusSettings()
-st.load_settings(os.path.join(SETTINGS_DIR, 'corpus.json'),
-                       os.path.join(SETTINGS_DIR, 'categories.json'))
-
-sc = SearchClient(SETTINGS_DIR, st)
-sentView = SentenceViewer(SETTINGS_DIR, sc)
-sc.qp.rp = sentView
-sc.qp.wr.rp = sentView
-random.seed()
-corpus_size = sc.get_n_words()  # size of the corpus in words
+sc = None
+sentView = None
+corpus_size = 0
 word_freq_by_rank = []
 lemma_freq_by_rank = []
-for lang in settings['languages']:
-    # number of word types for each frequency rank
-    word_freq_by_rank.append(
-        sentView.extract_cumulative_freq_by_rank(
-            sc.get_word_freq_by_rank(lang)))
-    # number of lemmata for each frequency rank
-    lemma_freq_by_rank.append(
-        sentView.extract_cumulative_freq_by_rank(
-            sc.get_lemma_freq_by_rank(lang)))
 linePlotMetafields = ['year']
+if SEARCH_BACKEND == "elasticsearch":
+    from folklore_app.search_engine.corpus_settings import CorpusSettings
+    from folklore_app.search_engine.response_processors import SentenceViewer
+    from folklore_app.search_engine.client import SearchClient
+
+    st = CorpusSettings()
+    st.load_settings(os.path.join(SETTINGS_DIR, 'corpus.json'),
+                           os.path.join(SETTINGS_DIR, 'categories.json'))
+
+    sc = SearchClient(SETTINGS_DIR, st)
+    sentView = SentenceViewer(SETTINGS_DIR, sc)
+    sc.qp.rp = sentView
+    sc.qp.wr.rp = sentView
+    random.seed()
+    corpus_size = sc.get_n_words()  # size of the corpus in words
+    for lang in settings['languages']:
+        # number of word types for each frequency rank
+        word_freq_by_rank.append(
+            sentView.extract_cumulative_freq_by_rank(
+                sc.get_word_freq_by_rank(lang)))
+        # number of lemmata for each frequency rank
+        lemma_freq_by_rank.append(
+            sentView.extract_cumulative_freq_by_rank(
+                sc.get_lemma_freq_by_rank(lang)))
 # metadata fields whose statistics can be displayed on a line plot
 sessionData = {}  # session key -> dictionary with the data for current session
 
@@ -369,6 +377,69 @@ def update_expanded_contexts(context, neighboringIDs):
                     neighboringIDs[lang][side])
 
 
+def build_es_sentence_context(n):
+    if n < 0:
+        return {}
+    sentData = get_session_data('sentence_data')
+    if sentData is None or n >= len(sentData) or 'languages' not in sentData[n]:
+        return {}
+    curSentData = sentData[n]
+    if curSentData['times_expanded'] >= settings['max_context_expand']:
+        return {}
+    context = {
+        'n': n,
+        'languages': {
+            lang: {}
+            for lang in curSentData['languages']
+        },
+        'src_alignment': {}
+    }
+    neighboringIDs = {
+        lang: {'next': -1, 'prev': -1}
+        for lang in curSentData['languages']
+    }
+    for lang in curSentData['languages']:
+        langID = settings['languages'].index(lang)
+        for side in ['next', 'prev']:
+            curCxLang = context['languages'][lang]
+            if side + '_id' in curSentData['languages'][lang]:
+                curCxLang[side] = sc.get_sentence_by_id(
+                    curSentData['languages'][lang][side + '_id'])
+            if (side in curCxLang
+                    and len(curCxLang[side]) > 0
+                    and 'hits' in curCxLang[side]
+                    and 'hits' in curCxLang[side]['hits']
+                    and len(curCxLang[side]['hits']['hits']) > 0):
+                lastSentNum = get_session_data('last_sent_num') + 1
+                curSent = curCxLang[side]['hits']['hits'][0]
+                if '_source' in curSent and (
+                        'lang' not in curSent['_source']
+                        or curSent['_source']['lang'] != langID):
+                    curCxLang[side] = ''
+                    continue
+                if ('_source' in curSent) \
+                        and (side + '_id' in curSent['_source']):
+                    neighboringIDs[lang][side] = (
+                        curSent['_source'][side + '_id'])
+                expandedContext = sentView.process_sentence(
+                    curSent,
+                    numSent=lastSentNum,
+                    getHeader=False,
+                    lang=lang,
+                    translit=get_session_data('translit'))
+                curCxLang[side] = expandedContext['languages'][lang]['text']
+                if settings['media']:
+                    sentView.relativize_src_alignment(
+                        expandedContext, curSentData['src_alignment_files'])
+                    context['src_alignment'].update(
+                        expandedContext['src_alignment'])
+                set_session_data('last_sent_num', lastSentNum)
+            else:
+                curCxLang[side] = ''
+    update_expanded_contexts(context, neighboringIDs)
+    return context
+
+
 @app.route('/search')
 def search_page():
     """
@@ -550,34 +621,30 @@ def find_sentences_json(page=0):
     return hits
 
 
+if SEARCH_BACKEND == "mysql":
+    search_backend = MySQLSearchBackend(max_page_size=MAX_PAGE_SIZE)
+else:
+    search_backend = ESSearchBackend(
+        find_sentences_json=find_sentences_json,
+        add_sent_to_session=add_sent_to_session,
+        sent_viewer=sentView,
+        settings=settings,
+        get_session_data=get_session_data,
+        set_session_data=set_session_data,
+        sync_page_data=sync_page_data,
+        build_context=build_es_sentence_context,
+    )
+
+
 @app.route('/search_sent/<int:page>')
 @app.route('/search_sent')
 @gzipped
 def search_sent(page=-1):
-    if page < 0:
-        set_session_data('page_data', {})
-        page = 0
-    hits = find_sentences_json(page=page)
-    add_sent_to_session(hits)
-    hitsProcessed = sentView.process_sent_json(
-        hits,
-        translit=get_session_data('translit'))
-    hitsProcessed['page'] = get_session_data('page')
-    hitsProcessed['page_size'] = get_session_data('page_size')
-    hitsProcessed['languages'] = settings['languages']
-    hitsProcessed['media'] = settings['media']
-    hitsProcessed['subcorpus_enabled'] = False
-    hitsProcessed['n_sentences'] = hitsProcessed['n_sentences']['value']
-    if 'subcorpus_enabled' in hits:
-        hitsProcessed['subcorpus_enabled'] = True
-    sync_page_data(hitsProcessed['page'], hitsProcessed)
-    maxPageNumber = (min(hitsProcessed['n_sentences'], 1000) - 1) \
-                    // hitsProcessed['page_size'] + 1
-    hitsProcessed['too_many_hits'] = (1000 < hitsProcessed['n_sentences'])
+    result = search_backend.search_sentences(request.args, page, session)
     return render_template(
         'tsa_blocks/result_sentences.html',
-        data=hitsProcessed,
-        max_page_number=maxPageNumber
+        data=result['data'],
+        max_page_number=result['max_page_number'],
     )
 
 
@@ -590,69 +657,7 @@ def get_sent_context(n):
     times this particular context has been expanded and
     whether expanding it further is allowed.
     """
-    if n < 0:
-        return jsonify({})
-    sentData = get_session_data('sentence_data')
-    # return jsonify({"l": len(sentData), "i": sentData[n]})
-    if sentData is None \
-            or n >= len(sentData) \
-            or 'languages' not in sentData[n]:
-        return jsonify({})
-    curSentData = sentData[n]
-    if curSentData['times_expanded'] >= settings['max_context_expand']:
-        return jsonify({})
-    context = {
-        'n': n,
-        'languages': {
-            lang: {}
-            for lang in curSentData['languages']
-        },
-        'src_alignment': {}
-    }
-    neighboringIDs = {
-        lang: {'next': -1, 'prev': -1}
-        for lang in curSentData['languages']
-    }
-    for lang in curSentData['languages']:
-        langID = settings['languages'].index(lang)
-        for side in ['next', 'prev']:
-            curCxLang = context['languages'][lang]
-            if side + '_id' in curSentData['languages'][lang]:
-                curCxLang[side] = sc.get_sentence_by_id(
-                    curSentData['languages'][lang][side + '_id'])
-            if (side in curCxLang
-                    and len(curCxLang[side]) > 0
-                    and 'hits' in curCxLang[side]
-                    and 'hits' in curCxLang[side]['hits']
-                    and len(curCxLang[side]['hits']['hits']) > 0):
-                lastSentNum = get_session_data('last_sent_num') + 1
-                curSent = curCxLang[side]['hits']['hits'][0]
-                if '_source' in curSent and (
-                        'lang' not in curSent['_source']
-                        or curSent['_source']['lang'] != langID):
-                    curCxLang[side] = ''
-                    continue
-                if ('_source' in curSent) \
-                        and (side + '_id' in curSent['_source']):
-                    neighboringIDs[lang][side] = (
-                        curSent['_source'][side + '_id'])
-                expandedContext = sentView.process_sentence(
-                    curSent,
-                    numSent=lastSentNum,
-                    getHeader=False,
-                    lang=lang,
-                    translit=get_session_data('translit'))
-                curCxLang[side] = expandedContext['languages'][lang]['text']
-                if settings['media']:
-                    sentView.relativize_src_alignment(
-                        expandedContext, curSentData['src_alignment_files'])
-                    context['src_alignment'].update(
-                        expandedContext['src_alignment'])
-                set_session_data('last_sent_num', lastSentNum)
-            else:
-                curCxLang[side] = ''
-    update_expanded_contexts(context, neighboringIDs)
-    return jsonify(context)
+    return jsonify(search_backend.get_sentence_context(n, session))
 
 
 @app.route('/get_word_fields')

--- a/folklore_app/tsakorpus_search.py
+++ b/folklore_app/tsakorpus_search.py
@@ -205,6 +205,17 @@ def set_session_data(fieldName, value):
     sessionData[session['session_id']][fieldName] = value
 
 
+def get_session_store():
+    """
+    Return the per-session data dictionary used for search state.
+    """
+    if 'session_id' not in session:
+        initialize_session()
+    if session['session_id'] not in sessionData:
+        sessionData[session['session_id']] = {}
+    return sessionData[session['session_id']]
+
+
 def change_display_options(query):
     """
     Remember the new display options provided in the query.
@@ -640,7 +651,8 @@ else:
 @app.route('/search_sent')
 @gzipped
 def search_sent(page=-1):
-    result = search_backend.search_sentences(request.args, page, session)
+    session_store = session if SEARCH_BACKEND != "mysql" else get_session_store()
+    result = search_backend.search_sentences(request.args, page, session_store)
     return render_template(
         'tsa_blocks/result_sentences.html',
         data=result['data'],
@@ -657,7 +669,8 @@ def get_sent_context(n):
     times this particular context has been expanded and
     whether expanding it further is allowed.
     """
-    return jsonify(search_backend.get_sentence_context(n, session))
+    session_store = session if SEARCH_BACKEND != "mysql" else get_session_store()
+    return jsonify(search_backend.get_sentence_context(n, session_store))
 
 
 @app.route('/get_word_fields')

--- a/migrations/mysql_search_index.sql
+++ b/migrations/mysql_search_index.sql
@@ -13,19 +13,3 @@ CREATE TABLE IF NOT EXISTS texts_sentences (
     INDEX idx_text_id (text_id),
     FULLTEXT INDEX ft_content_norm (content_norm)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-DROP PROCEDURE IF EXISTS sp_texts_sentences_reset;
-DELIMITER //
-CREATE PROCEDURE sp_texts_sentences_reset()
-BEGIN
-    TRUNCATE TABLE texts_sentences;
-END//
-DELIMITER ;
-
-DROP PROCEDURE IF EXISTS sp_texts_sentences_delete_for_text;
-DELIMITER //
-CREATE PROCEDURE sp_texts_sentences_delete_for_text(IN p_text_id INT)
-BEGIN
-    DELETE FROM texts_sentences WHERE text_id = p_text_id;
-END//
-DELIMITER ;

--- a/migrations/mysql_search_index.sql
+++ b/migrations/mysql_search_index.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS texts_sentences (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    text_id INT NOT NULL,
+    sent_no INT NOT NULL,
+    lang VARCHAR(16) NOT NULL DEFAULT 'default',
+    content LONGTEXT NOT NULL,
+    content_norm LONGTEXT NOT NULL,
+    year INT NULL,
+    geo VARCHAR(255) NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_text_sent (text_id, sent_no, lang),
+    INDEX idx_text_id (text_id),
+    FULLTEXT INDEX ft_content_norm (content_norm)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+DROP PROCEDURE IF EXISTS sp_texts_sentences_reset;
+DELIMITER //
+CREATE PROCEDURE sp_texts_sentences_reset()
+BEGIN
+    TRUNCATE TABLE texts_sentences;
+END//
+DELIMITER ;
+
+DROP PROCEDURE IF EXISTS sp_texts_sentences_delete_for_text;
+DELIMITER //
+CREATE PROCEDURE sp_texts_sentences_delete_for_text(IN p_text_id INT)
+BEGIN
+    DELETE FROM texts_sentences WHERE text_id = p_text_id;
+END//
+DELIMITER ;

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ retrying==1.3.3
 six==1.15.0
 SQLAlchemy==1.4.54
 tqdm==4.56.0
+typing_extensions==4.12.2
 urllib3==1.26.2
 Werkzeug==0.16.1
 WTForms==2.3.3

--- a/tests/test_context_mysql.py
+++ b/tests/test_context_mysql.py
@@ -1,0 +1,71 @@
+import importlib.util
+import os
+
+import pytest
+from sqlalchemy import text as sql_text
+from sqlalchemy.exc import SQLAlchemyError
+
+
+if importlib.util.find_spec("folklore_app.settings") is None:
+    pytest.skip("folklore_app.settings is missing; skipping MySQL tests.", allow_module_level=True)
+
+if not os.getenv("RUN_MYSQL_SEARCH_TESTS"):
+    pytest.skip("Set RUN_MYSQL_SEARCH_TESTS=1 to run MySQL search tests.", allow_module_level=True)
+
+os.environ["SEARCH_BACKEND"] = "mysql"
+
+from folklore_app import main_app  # noqa: E402
+from folklore_app.models import db, Texts  # noqa: E402
+from folklore_app.search_backends import mysql_indexer  # noqa: E402
+import folklore_app.tsakorpus_search  # noqa: E402,F401
+
+
+@pytest.fixture()
+def client():
+    app = main_app.application
+    with app.test_client() as client:
+        with app.app_context():
+            yield client
+
+
+def _ensure_search_schema():
+    try:
+        db.session.execute(sql_text("SELECT 1 FROM texts_sentences LIMIT 1"))
+    except SQLAlchemyError as exc:
+        pytest.skip(f"texts_sentences table missing or inaccessible: {exc}")
+
+    proc_exists = db.session.execute(
+        sql_text(
+            """
+            SELECT COUNT(*) AS total
+            FROM information_schema.ROUTINES
+            WHERE ROUTINE_NAME = 'sp_texts_sentences_delete_for_text'
+              AND ROUTINE_TYPE = 'PROCEDURE'
+            """
+        )
+    ).scalar()
+    if not proc_exists:
+        pytest.skip("Stored procedures for search indexing are missing.")
+
+
+def test_get_sent_context_mysql(client):
+    _ensure_search_schema()
+    text = Texts(raw_text="First sentence. Second sentence. Third sentence.")
+    db.session.add(text)
+    db.session.commit()
+    try:
+        mysql_indexer.index_text(text.id)
+        client.get("/search_sent", query_string={"txt": "Second"})
+        response = client.get("/get_sent_context/0")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert "languages" in data
+        assert "prev" in data["languages"]["default"]
+        assert "next" in data["languages"]["default"]
+    finally:
+        db.session.execute(
+            sql_text("DELETE FROM texts_sentences WHERE text_id = :text_id"),
+            {"text_id": text.id},
+        )
+        db.session.delete(text)
+        db.session.commit()

--- a/tests/test_context_mysql.py
+++ b/tests/test_context_mysql.py
@@ -17,7 +17,7 @@ os.environ["SEARCH_BACKEND"] = "mysql"
 from folklore_app import main_app  # noqa: E402
 from folklore_app.models import db, Texts  # noqa: E402
 from folklore_app.search_backends import mysql_indexer  # noqa: E402
-import folklore_app.tsakorpus_search  # noqa: E402,F401
+from folklore_app import tsakorpus_search  # noqa: E402,F401
 
 
 @pytest.fixture()

--- a/tests/test_context_mysql.py
+++ b/tests/test_context_mysql.py
@@ -12,16 +12,30 @@ if importlib.util.find_spec("folklore_app.settings") is None:
 if not os.getenv("RUN_MYSQL_SEARCH_TESTS"):
     pytest.skip("Set RUN_MYSQL_SEARCH_TESTS=1 to run MySQL search tests.", allow_module_level=True)
 
-os.environ["SEARCH_BACKEND"] = "mysql"
-
-from folklore_app import main_app  # noqa: E402
-from folklore_app.models import db, Texts  # noqa: E402
-from folklore_app.search_backends import mysql_indexer  # noqa: E402
-from folklore_app import tsakorpus_search  # noqa: E402,F401
+main_app = None
+db = None
+Texts = None
+mysql_indexer = None
+tsakorpus_search = None
 
 
 @pytest.fixture()
-def client():
+def client(monkeypatch):
+    global main_app, db, Texts, mysql_indexer, tsakorpus_search
+
+    monkeypatch.setenv("SEARCH_BACKEND", "mysql")
+
+    from folklore_app import main_app as _main_app  # noqa: E402
+    from folklore_app.models import db as _db, Texts as _Texts  # noqa: E402
+    from folklore_app.search_backends import mysql_indexer as _mysql_indexer  # noqa: E402
+    from folklore_app import tsakorpus_search as _tsakorpus_search  # noqa: E402,F401
+
+    main_app = _main_app
+    db = _db
+    Texts = _Texts
+    mysql_indexer = _mysql_indexer
+    tsakorpus_search = _tsakorpus_search
+
     app = main_app.application
     with app.test_client() as client:
         with app.app_context():

--- a/tests/test_context_mysql.py
+++ b/tests/test_context_mysql.py
@@ -48,19 +48,6 @@ def _ensure_search_schema():
     except SQLAlchemyError as exc:
         pytest.skip(f"texts_sentences table missing or inaccessible: {exc}")
 
-    proc_exists = db.session.execute(
-        sql_text(
-            """
-            SELECT COUNT(*) AS total
-            FROM information_schema.ROUTINES
-            WHERE ROUTINE_NAME = 'sp_texts_sentences_delete_for_text'
-              AND ROUTINE_TYPE = 'PROCEDURE'
-            """
-        )
-    ).scalar()
-    if not proc_exists:
-        pytest.skip("Stored procedures for search indexing are missing.")
-
 
 def test_get_sent_context_mysql(client):
     _ensure_search_schema()

--- a/tests/test_search_mysql.py
+++ b/tests/test_search_mysql.py
@@ -12,16 +12,30 @@ if importlib.util.find_spec("folklore_app.settings") is None:
 if not os.getenv("RUN_MYSQL_SEARCH_TESTS"):
     pytest.skip("Set RUN_MYSQL_SEARCH_TESTS=1 to run MySQL search tests.", allow_module_level=True)
 
-os.environ["SEARCH_BACKEND"] = "mysql"
-
-from folklore_app import main_app  # noqa: E402
-from folklore_app.models import db, Texts  # noqa: E402
-from folklore_app.search_backends import mysql_indexer  # noqa: E402
-from folklore_app import tsakorpus_search  # noqa: E402,F401
+main_app = None
+db = None
+Texts = None
+mysql_indexer = None
+tsakorpus_search = None
 
 
 @pytest.fixture()
-def client():
+def client(monkeypatch):
+    global main_app, db, Texts, mysql_indexer, tsakorpus_search
+
+    monkeypatch.setenv("SEARCH_BACKEND", "mysql")
+
+    from folklore_app import main_app as _main_app  # noqa: E402
+    from folklore_app.models import db as _db, Texts as _Texts  # noqa: E402
+    from folklore_app.search_backends import mysql_indexer as _mysql_indexer  # noqa: E402
+    from folklore_app import tsakorpus_search as _tsakorpus_search  # noqa: E402,F401
+
+    main_app = _main_app
+    db = _db
+    Texts = _Texts
+    mysql_indexer = _mysql_indexer
+    tsakorpus_search = _tsakorpus_search
+
     app = main_app.application
     with app.test_client() as client:
         with app.app_context():
@@ -57,7 +71,9 @@ def test_search_sent_mysql(client):
         mysql_indexer.index_text(text.id)
         response = client.get("/search_sent", query_string={"txt": "Second"})
         assert response.status_code == 200
-        assert "Second sentence" in response.get_data(as_text=True)
+        response_text = response.get_data(as_text=True)
+        assert "Second" in response_text
+        assert "sentence" in response_text
     finally:
         db.session.execute(
             sql_text("DELETE FROM texts_sentences WHERE text_id = :text_id"),

--- a/tests/test_search_mysql.py
+++ b/tests/test_search_mysql.py
@@ -17,7 +17,7 @@ os.environ["SEARCH_BACKEND"] = "mysql"
 from folklore_app import main_app  # noqa: E402
 from folklore_app.models import db, Texts  # noqa: E402
 from folklore_app.search_backends import mysql_indexer  # noqa: E402
-import folklore_app.tsakorpus_search  # noqa: E402,F401
+from folklore_app import tsakorpus_search  # noqa: E402,F401
 
 
 @pytest.fixture()

--- a/tests/test_search_mysql.py
+++ b/tests/test_search_mysql.py
@@ -1,0 +1,67 @@
+import importlib.util
+import os
+
+import pytest
+from sqlalchemy import text as sql_text
+from sqlalchemy.exc import SQLAlchemyError
+
+
+if importlib.util.find_spec("folklore_app.settings") is None:
+    pytest.skip("folklore_app.settings is missing; skipping MySQL tests.", allow_module_level=True)
+
+if not os.getenv("RUN_MYSQL_SEARCH_TESTS"):
+    pytest.skip("Set RUN_MYSQL_SEARCH_TESTS=1 to run MySQL search tests.", allow_module_level=True)
+
+os.environ["SEARCH_BACKEND"] = "mysql"
+
+from folklore_app import main_app  # noqa: E402
+from folklore_app.models import db, Texts  # noqa: E402
+from folklore_app.search_backends import mysql_indexer  # noqa: E402
+import folklore_app.tsakorpus_search  # noqa: E402,F401
+
+
+@pytest.fixture()
+def client():
+    app = main_app.application
+    with app.test_client() as client:
+        with app.app_context():
+            yield client
+
+
+def _ensure_search_schema():
+    try:
+        db.session.execute(sql_text("SELECT 1 FROM texts_sentences LIMIT 1"))
+    except SQLAlchemyError as exc:
+        pytest.skip(f"texts_sentences table missing or inaccessible: {exc}")
+
+    proc_exists = db.session.execute(
+        sql_text(
+            """
+            SELECT COUNT(*) AS total
+            FROM information_schema.ROUTINES
+            WHERE ROUTINE_NAME = 'sp_texts_sentences_delete_for_text'
+              AND ROUTINE_TYPE = 'PROCEDURE'
+            """
+        )
+    ).scalar()
+    if not proc_exists:
+        pytest.skip("Stored procedures for search indexing are missing.")
+
+
+def test_search_sent_mysql(client):
+    _ensure_search_schema()
+    text = Texts(raw_text="First sentence. Second sentence.")
+    db.session.add(text)
+    db.session.commit()
+    try:
+        mysql_indexer.index_text(text.id)
+        response = client.get("/search_sent", query_string={"txt": "Second"})
+        assert response.status_code == 200
+        assert "Second sentence" in response.get_data(as_text=True)
+    finally:
+        db.session.execute(
+            sql_text("DELETE FROM texts_sentences WHERE text_id = :text_id"),
+            {"text_id": text.id},
+        )
+        db.session.delete(text)
+        db.session.commit()

--- a/tests/test_search_mysql.py
+++ b/tests/test_search_mysql.py
@@ -48,19 +48,6 @@ def _ensure_search_schema():
     except SQLAlchemyError as exc:
         pytest.skip(f"texts_sentences table missing or inaccessible: {exc}")
 
-    proc_exists = db.session.execute(
-        sql_text(
-            """
-            SELECT COUNT(*) AS total
-            FROM information_schema.ROUTINES
-            WHERE ROUTINE_NAME = 'sp_texts_sentences_delete_for_text'
-              AND ROUTINE_TYPE = 'PROCEDURE'
-            """
-        )
-    ).scalar()
-    if not proc_exists:
-        pytest.skip("Stored procedures for search indexing are missing.")
-
 
 def test_search_sent_mysql(client):
     _ensure_search_schema()


### PR DESCRIPTION
### Motivation
- Prevent the application from attempting to initialize or connect to Elasticsearch when `SEARCH_BACKEND` is set to `mysql` and ensure the codebase remains compatible with Python 3.6's typing availability.
- Make the search backend selection explicit so MySQL-only deployments do not load ES-only modules or clients.

### Description
- Guarded ES-specific imports and the `SearchClient`/`SentenceViewer` initialization behind the `SEARCH_BACKEND == "elasticsearch"` check in `folklore_app/tsakorpus_search.py` and instantiate either `ESSearchBackend` or `MySQLSearchBackend` accordingly.
- Added `folklore_app/search_backends/base.py` that uses `typing.Protocol` with a fallback to `typing_extensions.Protocol` for Python 3.6 compatibility.
- Added `typing_extensions` to `requirements.txt` to ensure the fallback is available on older Python versions.
- Kept the backend abstraction intact so `search_sent` and `get_sent_context` routes call the selected backend via `search_backend.search_sentences` and `search_backend.get_sentence_context`.

### Testing
- Added gated MySQL tests `tests/test_search_mysql.py` and `tests/test_context_mysql.py` which exercise indexing and `/search_sent` + `/get_sent_context`, but these require `RUN_MYSQL_SEARCH_TESTS=1` and a proper MySQL schema and were not executed in this rollout.
- No automated tests were run in CI or locally for these changes as part of this patch (no runtime ES/MySQL connections were attempted while verifying the code changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988881a3a30832e8be595e88a29be95)